### PR TITLE
Update the status of commits on GitHub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ log = "0.3"
 regex = "0.1.80"
 slack-hook = { git = "https://github.com/ms705/rust-slack.git" }
 toml = "0.2.1"
+github-rs = "0.6"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ cargo run -- \
     --listen_addr 127.0.0.1:4567 \
     --github_repo "https://github.com/my/repo" \
     --secret "my_secret" \
+    --github_api_key "123key" \
     --slack_hook_url <SLACK_HOOK_URL> \
     --slack_channel "#chan"
 ```

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,12 +1,18 @@
 use Push;
 use Commit;
 use config::Config;
-use taste::{TastingResult};
+use taste::TastingResult;
+use github_rs::StatusCode;
 use github_rs::client::{Executor, Github};
-use serde_json::Value;
+use serde_json;
 
 pub struct GithubNotifier {
     api_token: String,
+}
+
+#[derive(Deserialize)]
+struct GithubError {
+    message: String,
 }
 
 #[derive(Serialize)]
@@ -18,23 +24,41 @@ struct Payload {
 
 impl GithubNotifier {
     pub fn new(api_token: &str) -> GithubNotifier {
-        GithubNotifier { api_token: String::from(api_token) }
+        GithubNotifier {
+            api_token: String::from(api_token),
+        }
     }
 
     fn post_status(&self, push: &Push, commit: &Commit, payload: &Payload) -> Result<(), String> {
+        let owner_name = push.owner_name.clone().unwrap();
+        let repo_name = push.repo_name.clone().unwrap();
+        println!(
+            "Setting status of {}/{}#{} to {}",
+            owner_name,
+            repo_name,
+            commit.id,
+            payload.state
+        );
+
         let client = Github::new(self.api_token.clone()).unwrap();
         let result = client
             .post(payload)
             .repos()
-            .owner(push.owner_name.clone().unwrap().as_str())
-            .repo(push.repo_name.clone().unwrap().as_str())
+            .owner(owner_name.as_str())
+            .repo(repo_name.as_str())
             .statuses()
             .sha(&commit.id.to_string())
-            .execute::<Value>();
+            .execute::<serde_json::Value>();
 
         match result {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.to_string()),
+            Ok((_, StatusCode::Created, Some(_))) => Ok(()),
+            Ok((_, status_code, Some(response))) => serde_json::from_value::<GithubError>(response)
+                .map_err(|err| {
+                    format!("Failed to parse error response ({}): {}", status_code, err)
+                })
+                .and_then(|err| Err(err.message.into())),
+            Ok((_, _, None)) => Err("Received error response from GitHub with no message".into()),
+            Err(err) => Err(format!("Failed to execute GitHub request: {}", err)),
         }
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,91 @@
+use Push;
+use config::Config;
+use taste::{TastingResult};
+use github_rs::client::{Executor, Github};
+use serde_json::Value;
+
+pub struct GithubNotifier {
+    api_token: String,
+}
+
+#[derive(Serialize)]
+struct Payload {
+    state: String,
+    description: String,
+    context: String,
+}
+
+impl GithubNotifier {
+    pub fn new(api_token: &str) -> GithubNotifier {
+        GithubNotifier { api_token: String::from(api_token) }
+    }
+
+    fn get_client(&self) -> Github {
+        Github::new(self.api_token.clone()).unwrap()
+    }
+
+    pub fn notify_pending(&self, push: &Push) -> Result<(), String> {
+        let payload = Payload {
+            state: String::from("pending"),
+            description: String::from("Currently tasting..."),
+            context: String::from("Taster"),
+        };
+
+        let result = self.get_client()
+            .post(&payload)
+            .repos()
+            .owner(push.owner_name.clone().unwrap().as_str())
+            .repo(push.repo_name.clone().unwrap().as_str())
+            .statuses()
+            // TODO: this shouldn't be head always
+            .sha(&push.head_commit.id.to_string())
+            .execute::<Value>();
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub fn notify(
+        &self,
+        _cfg: Option<&Config>,
+        res: &TastingResult,
+        push: &Push,
+    ) -> Result<(), String> {
+        let state = if !res.build || !res.test || !res.bench {
+            "failure"
+        } else {
+            "success"
+        };
+
+        let taste = if !res.build || !res.bench {
+            "was inedible"
+        } else if !res.test {
+            "had a mixed palate"
+        } else {
+            "tasted nice"
+        };
+
+        let payload = Payload {
+            state: state.to_string(),
+            description: format!("It {}.", taste),
+            context: "Taster".to_string(),
+        };
+
+        // TODO: move this to a method
+        let result = self.get_client()
+            .post(&payload)
+            .repos()
+            .owner(push.owner_name.clone().unwrap().as_str())
+            .repo(push.repo_name.clone().unwrap().as_str())
+            .statuses()
+            .sha(&push.head_commit.id.to_string())
+            .execute::<Value>();
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -29,7 +29,7 @@ impl GithubNotifier {
         }
     }
 
-    fn post_status(&self, push: &Push, commit: &Commit, payload: &Payload) -> Result<(), String> {
+    fn post_status(&self, push: &Push, commit: &Commit, payload: Payload) -> Result<(), String> {
         let owner_name = push.owner_name.clone().unwrap();
         let repo_name = push.repo_name.clone().unwrap();
         println!(
@@ -42,7 +42,7 @@ impl GithubNotifier {
 
         let client = Github::new(self.api_token.clone()).unwrap();
         let result = client
-            .post(payload)
+            .post(&payload)
             .repos()
             .owner(owner_name.as_str())
             .repo(repo_name.as_str())
@@ -69,7 +69,7 @@ impl GithubNotifier {
             description: "Currently tasting...".to_string(),
         };
 
-        self.post_status(push, commit, &payload)
+        self.post_status(push, commit, payload)
     }
 
     pub fn notify(
@@ -99,6 +99,6 @@ impl GithubNotifier {
             description: format!("It {}.", taste),
         };
 
-        self.post_status(push, commit, &payload)
+        self.post_status(push, commit, payload)
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,4 +1,5 @@
 use Push;
+use Commit;
 use config::Config;
 use taste::{TastingResult};
 use github_rs::client::{Executor, Github};
@@ -24,7 +25,7 @@ impl GithubNotifier {
         Github::new(self.api_token.clone()).unwrap()
     }
 
-    pub fn notify_pending(&self, push: &Push) -> Result<(), String> {
+    pub fn notify_pending(&self, push: &Push, commit: &Commit) -> Result<(), String> {
         let payload = Payload {
             state: String::from("pending"),
             description: String::from("Currently tasting..."),
@@ -37,8 +38,7 @@ impl GithubNotifier {
             .owner(push.owner_name.clone().unwrap().as_str())
             .repo(push.repo_name.clone().unwrap().as_str())
             .statuses()
-            // TODO: this shouldn't be head always
-            .sha(&push.head_commit.id.to_string())
+            .sha(&commit.id.to_string())
             .execute::<Value>();
 
         match result {
@@ -52,6 +52,7 @@ impl GithubNotifier {
         _cfg: Option<&Config>,
         res: &TastingResult,
         push: &Push,
+        commit: &Commit,
     ) -> Result<(), String> {
         let state = if !res.build || !res.test || !res.bench {
             "failure"
@@ -80,7 +81,7 @@ impl GithubNotifier {
             .owner(push.owner_name.clone().unwrap().as_str())
             .repo(push.repo_name.clone().unwrap().as_str())
             .statuses()
-            .sha(&push.head_commit.id.to_string())
+            .sha(&commit.id.to_string())
             .execute::<Value>();
 
         match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,7 +342,7 @@ pub fn main() {
                     repo_name: Some(repository.name.clone()),
                 };
 
-                let notify = |cfg: Option<&Config>, res: &taste::TastingResult, push: &Push| {
+                let notify = |cfg: Option<&Config>, res: &taste::TastingResult, push: &Push, commit: &Commit| {
                     // email notification
                     if en.is_some() {
                         en.as_ref().unwrap().notify(cfg, &res, &push).unwrap();
@@ -353,13 +353,13 @@ pub fn main() {
                     }
                     // github status notification
                     if gn.is_some() {
-                        gn.as_ref().unwrap().notify(cfg, &res, &push).unwrap();
+                        gn.as_ref().unwrap().notify(cfg, &res, &push, &commit).unwrap();
                     }
                 };
 
                 {
                     if gn.is_some() {
-                        gn.as_ref().unwrap().notify_pending(&push).unwrap();
+                        gn.as_ref().unwrap().notify_pending(&push, &push.head_commit).unwrap();
                     }
 
                     let ws = wsl.lock().unwrap();
@@ -383,7 +383,7 @@ pub fn main() {
                             )
                         }
                         Ok((cfg, tr)) => {
-                            notify(cfg.as_ref(), &tr, &push);
+                            notify(cfg.as_ref(), &tr, &push, &push.head_commit);
                             // Taste others if needed
                             if !taste_head_only {
                                 for c in commits.iter() {
@@ -413,7 +413,7 @@ pub fn main() {
                                                 e
                                             )
                                         }
-                                        Ok((cfg, tr)) => notify(cfg.as_ref(), &tr, &push),
+                                        Ok((cfg, tr)) => notify(cfg.as_ref(), &tr, &push, &cur_c),
                                     }
                                 }
                             } else if !commits.is_empty() {


### PR DESCRIPTION
This uses GitHub's [status API](https://developer.github.com/v3/repos/statuses/#create-a-status) to mark commits as pending, and then either failed or succeeded depending on the taster's outcome.

I've been using a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for this so far, but GitHub also supports making OAuth tokens [without the full web flow](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization). Note that if you use a personal access token the status updates will include the user's avatar, so might want to either create an application or just a separate bot user:

<img width="516" alt="screen shot 2017-10-03 at 3 31 13 am" src="https://user-images.githubusercontent.com/3536982/31134640-f8a51814-a862-11e7-9790-31ccfbd96a29.png">

The status doesn't currently link to anything, or contain any useful information. I think the best user experience would be to have it link to something that looked like the Slack message, with the possibility of seeing logs - but that's a future project.

I'm not sure how this works for forks, as you might not receive push events for branches outside your repository. To fix that we should probably listen for pull request events as well in the future. That way taster could also be run against the hidden merge commits GitHub creates for all pull requests: https://developer.github.com/v3/pulls/#get-a-single-pull-request